### PR TITLE
Add format attributes to functions to catch format-string bugs

### DIFF
--- a/RemoteLog.h
+++ b/RemoteLog.h
@@ -10,7 +10,7 @@
 #define RLOG_IP_ADDRESS "replace with ip"
 #define RLOG_PORT 11909
 
-__attribute__((unused)) static void RLogv(NSString* format, va_list args)
+__attribute__((unused)) NS_FORMAT_FUNCTION(1,0) static void RLogv(NSString* format, va_list args)
 {
     #if DEBUG
         NSString* str = [[NSString alloc] initWithFormat:format arguments:args];
@@ -49,7 +49,7 @@ __attribute__((unused)) static void RLogv(NSString* format, va_list args)
     #endif
 }
 
-__attribute__((unused)) static void RLog(NSString* format, ...)
+__attribute__((unused)) NS_FORMAT_FUNCTION(1,2) static void RLog(NSString* format, ...)
 {
     #if DEBUG
         va_list args;


### PR DESCRIPTION
Consider the following program

```objc
#import <Foundation/Foundation.h>
#import "RemoteLog.h"

int main() {
    RLog(@"xyz %@");
}
```

In current `master`, this code compiles without warnings. However, we observe there's a bug here, and `NSLog` would produce a warning for this code.

With the changes in this PR, clang now produces a diagnostic for this code:

```
5:14: warning: more '%' conversions than data arguments [-Wformat-insufficient-args]
    5 |         RLog(@"xyz %@");
      |                    ~^
```

Add we're able to resolve this warning; for example:

```objc
    RLog(@"xyz %@", @"sample");
```


---

This PR uses the same declarations as `NSLog` and `NSLogv` respectively.

```objc
FOUNDATION_EXPORT void NSLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL;
FOUNDATION_EXPORT void NSLogv(NSString *format, va_list args) NS_FORMAT_FUNCTION(1,0) NS_NO_TAIL_CALL;
```

---

For reference

```c
#define NS_FORMAT_FUNCTION(F,A) __attribute__((format(__NSString__, F, A)))
```